### PR TITLE
Making the website work properly on sunn.is-a.dev

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,9 @@
 baseurl: ""
 domain: ""
-url: "https://lynxmic.github.io"
+url: "https://sunn.is-a.dev/lynxwebsite"
 name: "Lynxmic"
 logo: "/img/logotype.png"
 currentyear: "2024"
 
 discord: "wDxDKJU2sj"
-source_url: "https://github.com/Lynxmic/lynxmic.github.io"
+source_url: "https://github.com/sunn-ia32/lynxwebsite"

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -18,13 +18,13 @@
         <strong>GPU</strong>: Intel FHD Graphics (integrated)
       </li>
       <li>
-       <strong>RAM</strong>: 4GB <i>(it's low for the current standards, but it does the job fairly well)</i>
+       <strong>RAM</strong>: 4GB <i>(it's low, but it does the job fairly well)</i>
       </li>
       <li>
         <strong>Storage</strong>: 256GB Samsung NVMe SSD (three-partition setup - Windows, Linux and data)
        </li>
        <li>
-        <strong>OS</strong>: Kubuntu 22.04.4 LTS & Windows 11 Pro 23H2
+        <strong>OS</strong>: Debian 12 & Windows 10 Pro 22H2
        </li>
        <li>
         <strong>Software used to make videos</strong>: GIMP 2.10 (graphic design), OBS Studio (recording/streaming), VMware Workstation Pro (virtualization), 86Box (emulation), DaVinci Resolve (editing - Windows), Kdenlive (editing - Linux)
@@ -40,15 +40,5 @@
         <strong>Phones</strong>: Samsung Galaxy A23 5G (main), Xiaomi Redmi 10 (secondary), Galaxy A20e (uhhh, backup?)
       </li>
     </ul>
-    <p class="subtitle" style="text-align:center;">🖥️ Buttons (because why not!)</p>
-    <div class="field is-grouped is-justify-content-center">
-      <p class="control">
-        <a href="https://wetdry.world/@lynxmic"><img src="https://760ceb3b9c0ba4872cadf3ce35a7a494.neocities.org/buttons/wetdry.world/wetdryworld-chuckya.png" style="image-rendering:pixelated;"></a>
-      </p>
-      <p class="control">
-        <a href="https://lynxmic.github.io/discord"><img src="https://cyber.dabamos.de/88x31/discord2.gif" style="image-rendering:pixelated;"></a>
-        
-      </p>
-    </div>
     </div>
     </div>

--- a/_includes/welcome.html
+++ b/_includes/welcome.html
@@ -2,6 +2,7 @@
   <div class="box is-align-items-center has-fade-effect mb-2" id="section">
     <p class="title" style="text-align:center;" id="greeting">👋 Hi there!</p>
     <p>Welcome to Lynxmic's personal website! Feel free to explore what's in store. Just switch between all these tabs or click on one of the buttons below to get started! :D</p>
+    <p><i>This website is no longer in active development. The new personal website is <a href="https://sunn.is-a.dev">sunn.is-a.dev</a>.</i></p>
     <p class="subtitle" style="text-align:center;">❔ Where do you want to go?</p>
     <div class="field is-grouped is-justify-content-center">
       <div class="control">

--- a/css/style.css
+++ b/css/style.css
@@ -1,26 +1,26 @@
 @font-face {
   font-family: "asap-regular";
-  src: url("https://lynxmic.github.io/blog/css/fonts/asap/Asap-Regular.otf");
+  src: url("https://sunn.is-a.dev/lynxblog/css/fonts/asap/Asap-Regular.otf");
  }
 @font-face {
   font-family: "asap-bold";
-  src: url("https://lynxmic.github.io/blog/css/fonts/asap/Asap-Bold.otf");
+  src: url("https://sunn.is-a.dev/lynxblog/css/fonts/asap/Asap-Bold.otf");
  }
 @font-face {
   font-family: "asap-bold-italic";
-  src: url("https://lynxmic.github.io/blog/css/fonts/asap/Asap-BoldItalic.otf");
+  src: url("https://sunn.is-a.dev/lynxblog/css/fonts/asap/Asap-BoldItalic.otf");
  }
 @font-face {
   font-family: "asap-italic";
-  src: url("https://lynxmic.github.io/blog/css/fonts/asap/Asap-Italic.otf");
+  src: url("https://sunn.is-a.dev/lynxblog/css/fonts/asap/Asap-Italic.otf");
  }
 @font-face {
   font-family: "asap-light";
-  src: url("https://lynxmic.github.io/blog/css/fonts/asap/Asap-Light.otf");
+  src: url("https://sunn.is-a.dev/lynxblog/css/fonts/asap/Asap-Light.otf");
  }
 @font-face {
   font-family: "asap-light-italic";
-  src: url("https://lynxmic.github.io/blog/css/fonts/asap/Asap-LightItalic.otf");
+  src: url("https://sunn.is-a.dev/lynxblog/css/fonts/asap/Asap-LightItalic.otf");
  }
  @keyframes gradient {
   0% {


### PR DESCRIPTION
As part of the online identity rebrand from Lynxmic to Sunn/sunn.ia32, which involved the migration of the website from the old lynxmic.github.io address to the new sunn.is-a.dev address, comes with a website rewrite.

This pull request ensures that the official Lynxmic website (also dubbed the "LynxWebsite") remains available and working, for historical purposes.